### PR TITLE
[semver:minor] New Parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.0] - 2022-08-26
+## [0.3.0] - 2022-08-26
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2022-08-26
+
+### Added
+
+- `increment-by-default` boolean parameter added.  This performs a patch release if no commit message is specified. Defaults to `false`
+
+### Changed
+
+- commit block is now case insensitive, allowing entries such as `[SemVer:Minor]`
+
 ## [0.1.0] - YYYY-MM-DD
 
 ### Added

--- a/src/commands/release.yml
+++ b/src/commands/release.yml
@@ -6,6 +6,10 @@ parameters:
     type: boolean
     default: true
     description: Include a changelog in the body of your GitHub release
+  increment_by_default:
+    type: boolean
+    default: false
+    description: Perfom a patch increment if no setting is provided
   initial-version-prefix:
     type: string
     default: v
@@ -16,6 +20,7 @@ steps:
   - run:
       environment:
         CHANGELOG: "<< parameters.changelog >>"
+        INCREMENT_BY_DEFAULT: "<< parameters.increment_by_default >>"
         INITIAL_VERSION_PREFIX: "<< parameters.initial-version-prefix >>"
       name: Create a GitHub release
       command: << include(scripts/release.sh) >>

--- a/src/commands/release.yml
+++ b/src/commands/release.yml
@@ -6,7 +6,7 @@ parameters:
     type: boolean
     default: true
     description: Include a changelog in the body of your GitHub release
-  increment_by_default:
+  increment-by-default:
     type: boolean
     default: false
     description: Perfom a patch increment if no setting is provided
@@ -20,7 +20,7 @@ steps:
   - run:
       environment:
         CHANGELOG: "<< parameters.changelog >>"
-        INCREMENT_BY_DEFAULT: "<< parameters.increment_by_default >>"
+        INCREMENT_BY_DEFAULT: "<< parameters.increment-by-default >>"
         INITIAL_VERSION_PREFIX: "<< parameters.initial-version-prefix >>"
       name: Create a GitHub release
       command: << include(scripts/release.sh) >>

--- a/src/scripts/release.sh
+++ b/src/scripts/release.sh
@@ -64,14 +64,19 @@ get_semver_increment() {
   local commit_subject
   commit_subject=$(git log -1 --pretty=%s.)
   semver_increment=$(echo "${commit_subject,,}" | sed -En 's/.*\[semver:(major|minor|patch|skip)\].*/\1/p')
+  if [ -z "$semver_increment" ] && [ $INCREMENT_BY_DEFAULT == "1" ]; then
+    semver_increment=patch
+  fi
 
   echo "Commit subject: $commit_subject"
   echo "SemVer increment: $semver_increment"
 
-  if [ -z "$semver_increment" ]; then
-    echo "Commit subject did not indicate which SemVer increment to make."
+  if [ -z "$semver_increment" ] && [ $INCREMENT_BY_DEFAULT == "0" ]; then
+    echo "Commit subject did not indicate which SemVer increment to make and increment_by_default is not set to true."
     echo "To create the tag and release, you can ammend the commit or push another commit with [semver:INCREMENT] in the subject where INCREMENT is major, minor, patch."
     echo "Note: To indicate intention to skip, include [semver:skip] in the commit subject instead."
+  elif [ $INCREMENT_BY_DEFAULT == "1" ]; then
+    echo  "Release is configured to always perform at least a patch release unless skip is specified"
   elif [ "$semver_increment" == "skip" ]; then
     echo "SemVer in commit indicated to skip release."
   fi

--- a/src/scripts/release.sh
+++ b/src/scripts/release.sh
@@ -63,7 +63,7 @@ release_github() {
 get_semver_increment() {
   local commit_subject
   commit_subject=$(git log -1 --pretty=%s.)
-  semver_increment=$(echo "$commit_subject" | sed -En 's/.*\[semver:(major|minor|patch|skip)\].*/\1/p')
+  semver_increment=$(echo "${commit_subject,,}" | sed -En 's/.*\[semver:(major|minor|patch|skip)\].*/\1/p')
 
   echo "Commit subject: $commit_subject"
   echo "SemVer increment: $semver_increment"


### PR DESCRIPTION
- `increment-by-default` Boolean parameter added.  This performs a patch release if no commit message is specified. Defaults to `false`
- commit block is now case insensitive, allowing entries such as `[SemVer:Minor]`
- update changelog to 0.3.0